### PR TITLE
Add ES6 and allow for JSX

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -1,10 +1,11 @@
 {
-  "env": {
-    "browser": true,
-    "jquery": true,
-    "node": true
+  "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module",
+      "ecmaFeatures": {
+          "jsx": true
+      }
   },
-  "globals": {},
   "rules": {
     "camelcase": [
       2,


### PR DESCRIPTION
jQuery and the like shouldn't be in the environment by default. 

Defacto should be ES6 and optionally allow for JSX since if we're using Javascript it's typically with React.